### PR TITLE
Temproray fix for: airbnb#522

### DIFF
--- a/lib/ios/AirMaps/AIRMap.m
+++ b/lib/ios/AirMaps/AIRMap.m
@@ -170,7 +170,8 @@ const NSInteger AIRMapMaxZoomLevel = 20;
     UIView *calloutMaybe = [self.calloutView hitTest:[self.calloutView convertPoint:point fromView:self] withEvent:event];
     if (calloutMaybe) return calloutMaybe;
 
-    return [super hitTest:point withEvent:event];
+    //return [super hitTest:point withEvent:event];
+    return ((UIView *)[((UIView *)[self.subviews objectAtIndex:0]).subviews objectAtIndex:2]);
 }
 
 #pragma mark SMCalloutViewDelegate


### PR DESCRIPTION
From: https://github.com/grundmanise/react-native-maps/commit/4e9457af2c0b9f1fbbc327a2f65765adfbb5c0bd

This disables marker onPress handler, interaction with a marker is available using onSelect instead.